### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://chrisjhoar.visualstudio.com/4a15f366-5d34-4a16-b438-22e5b01f9cc7/5e15a11b-c075-452d-adcd-c4297f6bff90/_apis/work/boardbadge/362e2b1f-19de-468e-9a48-f8284d2d57a9)](https://chrisjhoar.visualstudio.com/4a15f366-5d34-4a16-b438-22e5b01f9cc7/_boards/board/t/5e15a11b-c075-452d-adcd-c4297f6bff90/Microsoft.RequirementCategory)
 # Screen-Draw-Rooms
 This project was designed to test SignalR within .Net Core. It has evolved into an application where users can collaborate on drawings via "Sketch Rooms".
 ## Accessing the Demo


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#6](https://chrisjhoar.visualstudio.com/4a15f366-5d34-4a16-b438-22e5b01f9cc7/_workitems/edit/6). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.